### PR TITLE
Suppression espaces vides sur le noms des emplacements

### DIFF
--- a/cozytouch.py
+++ b/cozytouch.py
@@ -553,7 +553,7 @@ def read_label_from_cozytouch(data,x,oid='none'):
             except:
                 label=u'noname'
                 break
-    return label
+    return label.strip()
                     
 def decouverte_devices():
     


### PR DESCRIPTION
Modification mineure pour éviter les espaces " " dans le noms des appareils CozyTouch.