### PR TITLE
.gitignore: ignore generated or local conf files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+cozytouch_save.db
+ma_config.py


### PR DESCRIPTION
The idea is to NOT have these files in the "git status" output.